### PR TITLE
docs: rewrite multilingual READMEs in project voice

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,138 @@
+# All About Meow
+
+> **Haiiii, nice to meet yu, meow! (◕‿◕✿)**
+>
+> Dis iz a multilingual profile website all about **Yuri Nekotan**, also known as **Hyalurion**. It runs on Vue 3 n Vite magicks, with sakura petals floatin' down and purple sparklez everywhere. Come wander round mai tiny universe, nya~ ♡
+
+[日本語 README](./README.md) · [Visit da public site](https://yuri-self-info.netlify.app/)
+
+## 🌟 Wut can I do, meow?
+
+| Feature | Nekotan's lil explanation |
+| --- | --- |
+| 🗣️ **Mai Speeky Pocket** | I can switch between Japanese, English, Simple Chinese, and BIG Chinese! On ur furst visit, I peek at browser langwage n timezone to pick a comfy one for yu. |
+| ✨ **Shiny screen stuffs** | Loading screen, paw-licy consent screen, and a Canvas animation with sakura petals say haiiii to yu. |
+| 🎂 **Mai Secret Birfday Story** | A birthday countdown and lotsa profile sections tell yu little stories about me, nya~ |
+| 🔤 **Furigana n Bopomofo** | Japanese furigana and Traditional Chinese Bopomofo modes help the letters feelz friendly. |
+| 📜 **Da Paw-licy Paper** | Privacy policies in four langwages are written in Markdown and shown on their own page. |
+| 📝 **Changelog sparklez** | Release notes appear as pretty liquid-glass cards, so updates can look shiny too. |
+| 🎵 **BGM n GA4** | BGM playback and Googol Anal-nyaa-tics 4 are supported. For data stuffs, please read da consent screen n da Paw-licy Paper. |
+
+## 🌈 Come see mai universe
+
+The public site lives at [yuri-self-info.netlify.app](https://yuri-self-info.netlify.app/). Yu can choose langwage n page with URL parameters too, so yu can send a friend a link to exactly da screen yu foundz (◠‿◠✿)
+
+## 🐾 How to make it go zoom
+
+### Run da website
+
+Install Node.js, then say dese lil spells from da project root:
+
+```bash
+npm install
+npm run dev
+```
+
+When da dev server needs a nap, press `Ctrl+C` in da terminal. Nuuu, not forever—just for now, meow~
+
+### Build da production version
+
+```bash
+npm run build
+npm run preview
+```
+
+`npm run build` makes da production files, and `npm run preview` lets yu peek at da finished result. After changin' stuffs, make sure da build is happy, pleez~ ★
+
+## 🐱 JSON & Markdown Editor
+
+Inside `json-md-editor/` lives a PyQt6 desktop app made to help edit Self-Info data. It knows if a file iz i18n JSON, a changelog, a Paw-licy Paper Markdown, or just generic JSON / Markdown, then gives da file the right lil tools.
+
+Da live preview loads da built Vue app through QtWebEngine, so what yu see follows da real site frontend instead of a second renderer that might get confused. First run `npm run build` in da project root, den start da editor:
+
+```bash
+cd json-md-editor
+python -m venv .venv
+
+# macOS / Linux
+source .venv/bin/activate
+
+# Windows PowerShell:
+# .venv\Scripts\Activate.ps1
+
+pip install -r requirements.txt
+python main.py
+```
+
+It can format n validate JSON, wrap / unwrap rich text, add changelog entries, preview Markdown live, insert Paw-licy templates, auto-number headings, and export HTML / PDF. So many helpful tools—Nekotan feelz safe now (｡･ω･｡)ﾉ♡
+
+## 🔗 URL parameters
+
+| Parameter | Values | Wut it doez |
+| --- | --- | --- |
+| `?lang=` | `ja` / `en` / `zh-Hans` / `zh-TW` | Picks da display langwage. Share da URL and da same langwage comes back, meow. |
+| `?page=document` | none | Opens Da Paw-licy Paper. |
+| `?page=changelog` | none | Opens da changelog page. |
+| `?kana=1` | none | Turns on Japanese furigana or Traditional Chinese Bopomofo mode. |
+
+```text
+https://yuri-self-info.netlify.app/?lang=ja&kana=1
+https://yuri-self-info.netlify.app/?lang=en&page=changelog
+```
+
+## 📁 Mai tiny home
+
+```text
+.
+├── src/
+│   ├── App.vue                 # Teh top-level component
+│   ├── main.js                 # Where mai app starts
+│   ├── analytics.js            # Gets Googol Anal-nyaa-tics 4 ready
+│   ├── components/             # Header, footer, pages, and UI kittehs
+│   ├── composables/            # Langwage choice and page hoppin'
+│   ├── data/
+│   │   ├── i18n/               # Profile text in 4 langwages
+│   │   ├── legal/              # Paw-licy Papers in 4 langwages
+│   │   └── changelogs/         # Multilingual update notes
+│   ├── assets/                 # Animation n style stuffs
+│   └── preview-entry.js        # Editor preview entrance
+├── public/                     # Background, BGM, fonts, and static stuffs
+├── json-md-editor/             # JSON / Markdown editor app
+├── index.html
+├── preview.html
+├── package.json
+└── vite.config.js
+```
+
+## 💖 Langwage n asset sekrits
+
+Japanese n English use `KleeOne-Regular` and `NOTOSERIFJP-VF`; Simple Chinese uses `LXGWWenKaiGB-Regular`; BIG Chinese uses `LXGWWenKaiTC-Regular`. Da background image n BGM are shared by every langwage, so da shiny mood stays da same even when da words change, nya~
+
+Change profile n translation text in `src/data/i18n/`, Paw-licy Papers in `src/data/legal/`, and update notes in `src/data/changelogs/`. After editin', run `npm run build` to check if any syntax gremlinz are hiding.
+
+## 🛠️ Magic stuffs used here
+
+| Place | Magic name |
+| --- | --- |
+| Web | Vue 3, Vite |
+| Markdown | marked, DOMPurify |
+| Desktop editor | Python, PyQt6, PyQt6-WebEngine |
+| Shiny looks | CSS, langwage fonts, Canvas animation |
+| Visitor peekies | Googol Anal-nyaa-tics 4 |
+
+## 🍀 Nekotan's tiny request
+
+If yu add a new section or langwage, please keep da JSON keys lined up in every file. Yu can make da words as cute as yu like, but matching shapes keep Nekotan from gettin' lost in da forest, nya~
+
+Dis site wants personal info to be easy to read, easy to edit, and just a tiny bit dreamlike. Lets share a happy floaty universe together! ★
+
+## 📜 License n credits
+
+For license n asset rules, check da notices in da repository and da localized documents on da site. If yu replace or redistribute da background, BGM, fonts, or other external stuffs, please read each asset's rules first, fren.
+
+## References
+
+[1]: https://github.com/hyalurion/self-info "hyalurion/self-info repository"
+[2]: https://yuri-self-info.netlify.app/ "Self-Info public website"
+
+For da latest file structure, visit da [repository][1]. For da real shiny experience, visit da [public site][2]. Come play with Nekotan, meow!

--- a/README.md
+++ b/README.md
@@ -1,100 +1,138 @@
-# Self-Info
+# 自己紹介（にゃんこ日本語）
 
-A multilingual self-introduction website built with Vue 3 + Vite. Supports 4 languages: Japanese, English, Simplified Chinese (Malaysia/Singapore), and Traditional Chinese (Taiwan).
+> **はーい、はじめましてにゃん！ (◕‿◕✿)**
+>
+> ここは、琉璃ねこたんこと **Hyalurion** のことを、みんなにゆるっと知ってもらうための多言語プロフィールサイトだよ。Vue 3 と Vite の魔法で動いていて、桜がひらひら、紫色がきらきらしてるにゃ〜♡
 
-## Features
+[もっと詳しく（English）](./README.en.md) · [公開サイトで遊ぶにゃ！](https://yuri-self-info.netlify.app/)
 
-- Multilingual support (Japanese / English / Simplified Chinese / Traditional Chinese)
-  - Automatically detects the optimal language on first visit based on browser language, timezone, and optionally IP
-  - Manual switching via language selector (selection saved to localStorage)
-- Privacy policy consent screen
-- Loading animation
-- Cherry blossom (sakura) falling Canvas animation
-- Birthday countdown (4 languages supported)
-- Kana (Furigana) / Bopomofo display mode toggle (Japanese / Traditional Chinese)
-- Purple-based theme color (background, accents, section titles)
-- Language selection popup
-- Privacy consent page (written and displayed in Markdown for each language)
-- Changelog page — displayed with liquid glass-style cards
-- Google Analytics 4 support
-- BGM playback
+## 🌟 このサイトでできること
 
-## Getting Started
+| できること | ねこたんからのごあんない |
+| --- | --- |
+| 🗣️ **Mai Speeky Pocket** | 日本語・英語・簡体字中国語・繁体字中国語を、気分に合わせて切り替えられるよ。初めて来たときはブラウザの言語やタイムゾーンをちょっぴり見て、よさそうな言語を選ぶにゃ。 |
+| ✨ **きらきら画面** | ローディング画面、プライバシー同意画面、桜の花びらが舞う Canvas アニメーションでお出迎えするよ。 |
+| 🎂 **誕生秘密物語** | 誕生日カウントダウンと、プロフィールのいろいろなセクションを表示するにゃ。 |
+| 🔤 **ふりがな・注音** | 日本語ではふりがな、繁体字中国語では注音を表示できるよ。文字のおさんぽが楽しくなるね〜。 |
+| 📜 **Da Paw-licy Paper** | 4つの言語で書かれた Markdown のプライバシーポリシーを読めるにゃ。 |
+| 📝 **更新履歴** | changelog を液体ガラス風のカードにして、きらっと表示するよ。 |
+| 🎵 **BGM と GA4** | BGM の再生と Google Analytics 4 に対応してるにゃ。データについてはサイトの同意画面と各言語のポリシーを見てね。 |
+
+## 🌈 画面を見てみるにゃ
+
+公開版は [yuri-self-info.netlify.app](https://yuri-self-info.netlify.app/) にあるよ。言語やページを URL で指定できるから、「この画面を見てね〜」ってお友だちに渡すこともできるにゃ (◠‿◠✿)
+
+## 🐾 はじめかた
+
+### ウェブサイトを起動するにゃ
+
+Node.js を用意して、プロジェクトのルートで次の呪文を唱えてね。
 
 ```bash
 npm install
 npm run dev
 ```
 
-## Build
+開発サーバーを止めるときは、ターミナルで `Ctrl+C` を押せば大丈夫だよ。ねこたんもお昼寝するにゃ〜。
+
+### 本番用にビルドするにゃ
 
 ```bash
 npm run build
+npm run preview
 ```
 
-## Project Structure
+`npm run build` で本番用ファイルを作って、`npm run preview` でできあがりを確認できるよ。書き換えたあとは、ビルドが成功するか見てあげてねっ★
 
-```
-src/
-├── analytics.js              # Google Analytics 4 initialization
-├── main.js                   # Entry point
-├── App.vue                   # Root component
-├── assets/
-│   ├── anime/                # Animation assets
-│   └── styles/               # Component styles
-├── components/
-│   ├── sections/
-│   │   ├── BirthdayCountdown.vue  # Birthday countdown component
-│   │   └── SectionRenderer.vue    # Section dynamic rendering
-│   ├── ChangelogPage.vue     # Changelog page
-│   ├── DocumentPage.vue      # Privacy policy consent page (Markdown)
-│   ├── KanaSwitch.vue        # Kana / Bopomofo display mode toggle
-│   ├── LanguageSelector.vue  # Language selector
-│   ├── LoadingScreen.vue     # Loading screen
-│   ├── MarkdownRenderer.vue  # Markdown rendering (marked + DOMPurify)
-│   ├── PageFooter.vue        # Footer
-│   ├── PageHeader.vue        # Header
-│   ├── RichText.vue          # Rich text display
-│   ├── SakuraCanvas.vue      # Cherry blossom Canvas animation
-│   ├── SplashScreen.vue      # Privacy policy consent screen
-│   └── UIElements.vue        # UI elements
-├── composables/
-│   ├── useI18n.js            # Language detection and selection
-│   └── useNav.js             # Page navigation (?page=document / ?page=changelog)
-├── data/
-│   ├── i18n/
-│   │   ├── ja.json          # Japanese content
-│   │   ├── en.json          # English content
-│   │   ├── zh-Hans.json     # Simplified Chinese content
-│   │   └── zh-TW.json       # Traditional Chinese content
-│   ├── legal/
-│   │   ├── ja.md            # Privacy policy (Japanese)
-│   │   ├── en.md            # Privacy policy (English)
-│   │   ├── zh-Hans.md       # Privacy policy (Simplified Chinese)
-│   │   └── zh-TW.md         # Privacy policy (Traditional Chinese)
-│   └── changelogs/
-│       ├── ja.json          # Changelog (Japanese)
-│       ├── en.json          # Changelog (English)
-│       ├── zh.json          # Changelog (Simplified Chinese)
-│       └── tw.json          # Changelog (Traditional Chinese)
-└── public/                   # Static assets (background, BGM, fonts)
+## 🐱 JSON / Markdown エディタ
+
+`json-md-editor/` には、Self-Info のデータを編集するための PyQt6 製デスクトップアプリが入ってるにゃ。i18n の JSON、changelog、プライバシーポリシーの Markdown、ふつうの JSON / Markdown を、ファイルの役割に合わせてお手伝いしてくれるよ。
+
+サイト本体の表示をそのままプレビューできるように、ビルド済みの Vue アプリを QtWebEngine に読み込む仕組みになってるにゃ。だから、まずプロジェクトルートで `npm run build` をしてからエディタを起動してね。
+
+```bash
+cd json-md-editor
+python -m venv .venv
+
+# macOS / Linux
+source .venv/bin/activate
+
+# Windows PowerShell の場合
+# .venv\Scripts\Activate.ps1
+
+pip install -r requirements.txt
+python main.py
 ```
 
-## Language & Asset Management
+JSON の整形・検証、リッチテキストのラップ／アンラップ、changelog の追加、Markdown のライブプレビュー、プライバシーポリシーのテンプレート、見出しの自動採番、HTML / PDF 出力などができるよ。編集のお手伝いがいっぱいで、ねこたんも安心にゃ (｡･ω･｡)ﾉ♡
 
-- **Background Image**: The Japanese version `public/pic/bg.avif` is shared across all languages
-- **BGM**: The Japanese version `public/bgm/bgm_kokoronashi.opus` is shared across all languages
-- **Fonts**: Different fonts are used for each language
-  - Japanese / English: `KleeOne-Regular` + `NOTOSERIFJP-VF`
-  - Simplified Chinese: `LXGWWenKaiGB-Regular`
-  - Traditional Chinese: `LXGWWenKaiTC-Regular`
-  - CSS variable `--app-font` is switched via `:root[data-lang]`
+## 🔗 URL パラメータ
 
-## URL Parameters
-
-| Parameter | Values | Description |
+| パラメータ | 値 | なにが起きるの？ |
 | --- | --- | --- |
-| `?lang=` | `ja` / `en` / `zh-Hans` / `zh-TW` | Specifies the current language (can be reproduced via URL sharing · highest priority). Other parameters are preserved |
-| `?page=document` | — | Displays the Privacy Policy page |
-| `?page=changelog` | — | Displays the Changelog page |
-| `?kana=1` | — | Enables Kana (Furigana) / Bopomofo mode (Japanese · Traditional Chinese) |
+| `?lang=` | `ja` / `en` / `zh-Hans` / `zh-TW` | 表示言語を指定するよ。URL を共有しても、その言語を再現できるにゃ。 |
+| `?page=document` | なし | プライバシーポリシーを開くよ。 |
+| `?page=changelog` | なし | 更新履歴を開くよ。 |
+| `?kana=1` | なし | 日本語のふりがな、または繁体字中国語の注音を表示するにゃ。 |
+
+```text
+https://yuri-self-info.netlify.app/?lang=ja&kana=1
+https://yuri-self-info.netlify.app/?lang=en&page=changelog
+```
+
+## 📁 ねこたんのおうち
+
+```text
+.
+├── src/
+│   ├── App.vue                 # いちばん上のコンポーネント
+│   ├── main.js                 # はじまりの入口
+│   ├── analytics.js            # Google Analytics 4 の準備
+│   ├── components/             # ヘッダー、フッター、ページ、UI たち
+│   ├── composables/            # 言語選択とページ移動のお手伝い
+│   ├── data/
+│   │   ├── i18n/               # 4言語分のプロフィール文章
+│   │   ├── legal/              # 4言語分のプライバシーポリシー
+│   │   └── changelogs/         # 多言語の更新履歴
+│   ├── assets/                 # アニメーションとスタイル
+│   └── preview-entry.js        # エディタのプレビュー入口
+├── public/                     # 背景、BGM、フォントなど
+├── json-md-editor/             # JSON / Markdown 編集用の小さなアプリ
+├── index.html
+├── preview.html
+├── package.json
+└── vite.config.js
+```
+
+## 💖 言語と素材のひみつ
+
+日本語と英語には `KleeOne-Regular` と `NOTOSERIFJP-VF`、簡体字中国語には `LXGWWenKaiGB-Regular`、繁体字中国語には `LXGWWenKaiTC-Regular` を使ってるよ。背景画像と BGM は、どの言語でも同じものを共有するにゃ。言語が変わっても、きらきらの雰囲気は変わらないのだ〜。
+
+プロフィールや翻訳を変えるときは `src/data/i18n/`、プライバシーポリシーは `src/data/legal/`、更新履歴は `src/data/changelogs/` を見てね。文章を書き換えたら、最後に `npm run build` でエラーがないか確認すると安心だよ。
+
+## 🛠️ 使っている魔法
+
+| ところ | 魔法の名前 |
+| --- | --- |
+| ウェブ | Vue 3、Vite |
+| Markdown | marked、DOMPurify |
+| デスクトップエディタ | Python、PyQt6、PyQt6-WebEngine |
+| 見た目 | CSS、言語ごとのフォント、Canvas アニメーション |
+| アクセス解析 | Google Analytics 4 |
+
+## 🍀 ねこたんからのお願い
+
+新しいセクションや翻訳を追加するときは、各言語の JSON の形をそろえてね。文章の中身はそれぞれの言語で自由に可愛くしていいけれど、キーの形がそろっていると、ねこたんが迷子にならないにゃ。
+
+このサイトは、自己紹介を読みやすく、編集しやすく、ほんの少し夢みたいにするための場所だよ。一緒にしあわせなふわふわ宇宙を分け合おうね〜★
+
+## 📜 ライセンスとクレジット
+
+ライセンスや素材の利用条件は、リポジトリ内の表示とサイトの各言語のドキュメントを確認してね。背景画像、BGM、フォントなどを差し替えたり再配布したりするときは、それぞれの条件をちゃんと読むにゃ。
+
+## 参照
+
+[1]: https://github.com/hyalurion/self-info "hyalurion/self-info repository"
+[2]: https://yuri-self-info.netlify.app/ "Self-Info public website"
+
+最新のファイル構成は [リポジトリ本体][1]、実際のきらきら画面は [公開サイト][2] で見られるよ。遊びにきてね、にゃん！


### PR DESCRIPTION
## Summary

このPRは、Self-Info のウェブ版 i18n テキストに合わせて README を書き直すものです。

## Changes

- `README.md` を日本語の主READMEとして全面改稿しました。
- `src/data/i18n/ja.json` の「ねこたん」「にゃ」「〜」「♡」「★」などの可愛い表現に合わせました。
- `README.en.md` を追加しました。
- `src/data/i18n/en.json` の「wut」「iz」「mai」「moar」「paw-licy」「meow」「nya」などの萌え猫語調に合わせました。
- プロジェクトの機能、開発コマンド、JSON / Markdown Editor、URLパラメータ、ディレクトリ構成、技術スタックを両言語で整理しました。

## Verification

- `git diff --check` passed.
- README内のリンク、ビルドコマンド、公開サイトURLを確認済みです。

Please review the wording and merge when ready, meow~
