### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/count-lines.yml
+++ b/.github/workflows/count-lines.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   count-loc:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/hyalurion/self-info/security/code-scanning/2](https://github.com/hyalurion/self-info/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root in `.github/workflows/count-lines.yml`, directly under `on:` and before `jobs:`.  
For this workflow, `contents: read` is the appropriate minimal permission and aligns with CodeQL’s recommendation. This avoids changing behavior while ensuring the token cannot get broader rights from repository/organization defaults.

No imports, methods, or dependencies are needed—only YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
